### PR TITLE
Update Two Factor auth_variants location

### DIFF
--- a/xbox_webapi/authentication/two_factor.py
+++ b/xbox_webapi/authentication/two_factor.py
@@ -245,7 +245,7 @@ class TwoFactorAuthentication(object):
             requests.Response: Instance of :class:`requests.Response`. Access / Refresh Tokens are contained in the
             Location-Header!
         """
-        auth_variants = server_data.get('H', [])
+        auth_variants = server_data.get('D', [])
         if not len(auth_variants):
             log.error('No TwoFactor Auth Methods available?! That\'s weird!')
             return


### PR DESCRIPTION
In my local testing, the auth_variants were in server data 'D', not 'H'.
H only had a value of 'false'.